### PR TITLE
Update ref_log.rs

### DIFF
--- a/src/file_hiding/ref_log.rs
+++ b/src/file_hiding/ref_log.rs
@@ -1,10 +1,14 @@
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{self, Read, Write};
 
 pub type Hash = String;
 const REFS_DIR: &str = "./test/.geet/refs";
+
 /// Creates a new Ref object and writes it to `./geet/refs`.
 pub fn store_ref(name: &String, data: &String) -> io::Result<()> {
+    // Create all necessary parent directories
+    fs::create_dir_all(REFS_DIR)?;
+    
     let path = format!("{}/{}", REFS_DIR, name);
     let mut file = File::create(&path)?;
     file.write_all(data.as_bytes())?;


### PR DESCRIPTION
adding fs::create_dir_all(REFS_DIR)?; at the beginning of store_ref to ensure directory path exists before file creation